### PR TITLE
Adding default values to keyword arguments.

### DIFF
--- a/lib/insightly2/dsl/comments.rb
+++ b/lib/insightly2/dsl/comments.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A comment's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Comment, nil].
-    def get_comment(id:)
+    def get_comment(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Comment.parse(request(:get, "Comments/#{id}"))
     end
@@ -18,7 +18,7 @@ module Insightly2
     # @param [String] filename The name of the attachment.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def create_comment_attachment(id:, filename:)
+    def create_comment_attachment(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:post, "Comments/?c_id=#{id}&filename=#{filename}")
@@ -29,7 +29,7 @@ module Insightly2
     # @param [Hash] comment The comment to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Comment, nil].
-    def update_comment(comment:)
+    def update_comment(comment: nil)
       raise ArgumentError, "Comment cannot be blank" if comment.blank?
       Resources::Comment.parse(request(:put, "Comments", comment))
     end
@@ -39,7 +39,7 @@ module Insightly2
     # @param [String, Fixnum] id A comment's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_comment(id:)
+    def delete_comment(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Comments/#{id}")
     end

--- a/lib/insightly2/dsl/contacts.rb
+++ b/lib/insightly2/dsl/contacts.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id The ID of the contact.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Contact, nil].
-    def get_contact(id:)
+    def get_contact(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Contact.parse(request(:get, "Contacts/#{id}"))
     end
@@ -17,7 +17,7 @@ module Insightly2
     # @param [id:] id of the contact.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_contact_emails(id:)
+    def get_contact_emails(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Email.parse(request(:get, "Contacts/#{id}/Emails"))
     end
@@ -27,7 +27,7 @@ module Insightly2
     # @param [String, Fixnum] id The ID of the contact.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def get_contact_image(id:)
+    def get_contact_image(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:get, "Contacts/#{id}/Image")
     end
@@ -37,7 +37,7 @@ module Insightly2
     # @param [String, Fixnum] id The ID of the contact.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_contact_notes(id:)
+    def get_contact_notes(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Note.parse(request(:get, "Contacts/#{id}/Notes"))
     end
@@ -47,7 +47,7 @@ module Insightly2
     # @param [String, Fixnum] id The ID of the contact.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_contact_tasks(id:)
+    def get_contact_tasks(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Task.parse(request(:get, "Contacts/#{id}/Tasks"))
     end
@@ -68,7 +68,7 @@ module Insightly2
     # @param [Hash] contact The contact to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Contact, nil].
-    def create_contact(contact:)
+    def create_contact(contact: nil)
       raise ArgumentError, "Contact cannot be blank" if contact.blank?
       Resources::Contact.parse(request(:post, "Contacts", contact))
     end
@@ -79,7 +79,7 @@ module Insightly2
     # @param [String] filename The name of image file to be attached to the contact.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def create_contact_image(id:, filename:)
+    def create_contact_image(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:post, "Contacts/#{id}/Image/#{filename}")
@@ -90,7 +90,7 @@ module Insightly2
     # @param [Hash] contact The contact to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Contact, nil].
-    def update_contact(contact:)
+    def update_contact(contact: nil)
       raise ArgumentError, "Contact cannot be blank" if contact.blank?
       Resources::Contact.parse(request(:put, "Contacts", contact))
     end
@@ -101,7 +101,7 @@ module Insightly2
     # @param [String] filename The name of image file to be attached to the contact.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def update_contact_image(id:, filename:)
+    def update_contact_image(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:put, "Contacts/#{id}/Image/#{filename}")
@@ -112,7 +112,7 @@ module Insightly2
     # @param [String, Fixnum] id The ID of the contact to delete.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_contact(id:)
+    def delete_contact(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Contacts/#{id}")
     end
@@ -122,7 +122,7 @@ module Insightly2
     # @param [String, Fixnum] id The ID of the contact with the image to delete.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_contact_image(id:)
+    def delete_contact_image(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Contacts/#{id}/Image")
     end

--- a/lib/insightly2/dsl/custom_fields.rb
+++ b/lib/insightly2/dsl/custom_fields.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A CustomField's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::CustomField, nil].
-    def get_custom_field(id:)
+    def get_custom_field(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::CustomField.parse(request(:get, "CustomFields/#{id}"))
     end

--- a/lib/insightly2/dsl/emails.rb
+++ b/lib/insightly2/dsl/emails.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id The ID of the email.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Email, nil]
-    def get_email(id:)
+    def get_email(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Email.parse(request(:get, "Emails/#{id}"))
     end
@@ -17,7 +17,7 @@ module Insightly2
     # @param [String, Fixnum] id The ID of the email.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_email_comments(id:)
+    def get_email_comments(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Comment.parse(request(:get, "Emails/#{id}/Comments"))
     end
@@ -38,7 +38,7 @@ module Insightly2
     # @param [Hash] comment The comment to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def create_email_comment(id:, comment:)
+    def create_email_comment(id: nil, comment: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Comment cannot be blank" if comment.blank?
       request(:post, "Emails/#{id}/Comments", comment)
@@ -49,7 +49,7 @@ module Insightly2
     # @param [String, Fixnum] id The ID of the email to delete.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_email(id:)
+    def delete_email(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Emails/#{id}")
     end

--- a/lib/insightly2/dsl/events.rb
+++ b/lib/insightly2/dsl/events.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id An event's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Event, nil].
-    def get_event(id:)
+    def get_event(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Event.parse(request(:get, "Events/#{id}"))
     end
@@ -24,7 +24,7 @@ module Insightly2
     # @param [Hash] event The event to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Event, nil]
-    def create_event(event:)
+    def create_event(event: nil)
       raise ArgumentError, "Event cannot be blank" if event.blank?
       Resources::Event.parse(request(:post, "Events", event))
     end
@@ -34,7 +34,7 @@ module Insightly2
     # @param [Hash] event The event to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Event, nil]
-    def update_event(event:)
+    def update_event(event: nil)
       raise ArgumentError, "Event cannot be blank" if event.blank?
       Resources::Event.parse(request(:put, "Events", event))
     end
@@ -44,7 +44,7 @@ module Insightly2
     # @param [String, Fixnum] id An event's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_event(id:)
+    def delete_event(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Events/#{id}")
     end

--- a/lib/insightly2/dsl/file_attachments.rb
+++ b/lib/insightly2/dsl/file_attachments.rb
@@ -6,7 +6,7 @@ module Insightly2
     # @param [String, Fixnum] id A file attachment's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def get_file_attachment(id:)
+    def get_file_attachment(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:get, "FileAttachments/#{id}")
     end

--- a/lib/insightly2/dsl/file_categories.rb
+++ b/lib/insightly2/dsl/file_categories.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id: A file category's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::FileCategory, nil].
-    def get_file_category(id:)
+    def get_file_category(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::FileCategory.parse(request(:get, "FileCategories/#{id}"))
     end
@@ -24,7 +24,7 @@ module Insightly2
     # @param [Hash] category: File Category attributes.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::FileCategory, nil].
-    def create_file_category(category:)
+    def create_file_category(category: nil)
       raise ArgumentError, "Category cannot be blank" if category.blank?
       Resources::FileCategory.parse(request(:post, "FileCategories", category))
     end
@@ -34,7 +34,7 @@ module Insightly2
     # @param [Hash] category: File Category attributes.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::FileCategory].
-    def update_file_category(category:)
+    def update_file_category(category: nil)
       raise ArgumentError, "Category cannot be blank" if category.blank?
       Resources::FileCategory.parse(request(:put, "FileCategories", category))
     end
@@ -44,7 +44,7 @@ module Insightly2
     # @param [String, Fixnum] id: A file category's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_file_category(id:)
+    def delete_file_category(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "FileCategories/#{id}")
     end

--- a/lib/insightly2/dsl/notes.rb
+++ b/lib/insightly2/dsl/notes.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A note's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Note, nil].
-    def get_note(id:)
+    def get_note(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Note.parse(request(:get, "Notes/#{id}"))
     end
@@ -17,7 +17,7 @@ module Insightly2
     # @param [String, Fixnum] id A note's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_note_comments(id:)
+    def get_note_comments(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Comment.parse(request(:get, "Notes/#{id}/Comments"))
     end
@@ -34,7 +34,7 @@ module Insightly2
     # @param [Hash] note The note to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Note, nil].
-    def create_note(note:)
+    def create_note(note: nil)
       raise ArgumentError, "Note cannot be blank" if note.blank?
       Resources::Note.parse(request(:post, "Notes", note))
     end
@@ -45,7 +45,7 @@ module Insightly2
     # @param [String] comment The comment to add to the note.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def create_note_comment(id:, comment:)
+    def create_note_comment(id: nil, comment: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Comment cannot be blank" if comment.blank?
       request(:post, "Notes/#{id}/Comments", comment)
@@ -57,7 +57,7 @@ module Insightly2
     # @param [String] filename The name of the file.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def create_note_file(id:, filename:)
+    def create_note_file(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:post, "Notes?c_id=#{id}&filename=#{filename}")
@@ -68,7 +68,7 @@ module Insightly2
     # @param [Hash] note The note to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Note, nil].
-    def update_note(note:)
+    def update_note(note: nil)
       raise ArgumentError, "Note cannot be blank" if note.blank?
       Resources::Note.parse(request(:put, "Notes", note))
     end
@@ -77,7 +77,7 @@ module Insightly2
     # @param [String, Fixnum] id A note's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_note(id:)
+    def delete_note(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Notes/#{id}")
     end

--- a/lib/insightly2/dsl/opportunities.rb
+++ b/lib/insightly2/dsl/opportunities.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id An opportunity's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Opportunity, nil].
-    def get_opportunity(id:)
+    def get_opportunity(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Opportunity.parse(request(:get, "Opportunities/#{id}"))
     end
@@ -17,7 +17,7 @@ module Insightly2
     # @param [String, Fixnum] id An opportunity's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_opportunity_emails(id:)
+    def get_opportunity_emails(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Email.parse(request(:get, "Opportunities/#{id}/Emails"))
     end
@@ -26,7 +26,7 @@ module Insightly2
     # @param [String, Fixnum] id An opportunity's ID
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response]
-    def get_opportunity_image(id:)
+    def get_opportunity_image(id: nil)
       request(:get, "Opportunities/#{id}/Image")
     end
 
@@ -35,7 +35,7 @@ module Insightly2
     # @param [String, Fixnum] id An opportunity's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_opportunity_notes(id:)
+    def get_opportunity_notes(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Note.parse(request(:get, "Opportunities/#{id}/Notes"))
     end
@@ -45,7 +45,7 @@ module Insightly2
     # @param [String, Fixnum] id An opportunity's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_opportunity_state_history(id:)
+    def get_opportunity_state_history(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::OpportunityStateReason.parse(request(:get, "Opportunities/#{id}/StateHistory"))
     end
@@ -55,7 +55,7 @@ module Insightly2
     # @param [String, Fixnum] id An opportunity's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_opportunity_tasks(id:)
+    def get_opportunity_tasks(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Task.parse(request(:get, "Opportunities/#{id}/Tasks"))
     end
@@ -75,7 +75,7 @@ module Insightly2
     # @param [Hash] opportunity The opportunity to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Opportunity, nil].
-    def create_opportunity(opportunity:)
+    def create_opportunity(opportunity: nil)
       raise ArgumentError, "Opportunity cannot be blank" if opportunity.blank?
       Resources::Opportunity.parse(request(:post, "Opportunities", opportunity))
     end
@@ -86,7 +86,7 @@ module Insightly2
     # @param [String] filename A name of a file.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response]
-    def create_opportunity_image(id:, filename:)
+    def create_opportunity_image(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:post, "Opportunities/#{id}/Image/#{filename}")
@@ -97,7 +97,7 @@ module Insightly2
     # @param [Hash] opportunity The opportunity to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Opportunity, nil]
-    def update_opportunity(opportunity:)
+    def update_opportunity(opportunity: nil)
       raise ArgumentError, "Opportunity cannot be blank" if opportunity.blank?
       Resources::Opportunity.parse(request(:put, "Opportunities", opportunity))
     end
@@ -107,7 +107,7 @@ module Insightly2
     # @param [String] filename A name of a file.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def update_opportunity_image(id:, filename:)
+    def update_opportunity_image(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:put, "Opportunities/#{id}/Image/#{filename}")
@@ -117,7 +117,7 @@ module Insightly2
     # @param [String, Fixnum] id An opportunity's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_opportunity(id:)
+    def delete_opportunity(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Opportunities/#{id}")
     end
@@ -126,7 +126,7 @@ module Insightly2
     # @param [String, Fixnum] id An opportunity's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_opportunity_image(id:)
+    def delete_opportunity_image(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Opportunities/#{id}/Image")
     end

--- a/lib/insightly2/dsl/opportunity_categories.rb
+++ b/lib/insightly2/dsl/opportunity_categories.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id An opportunity category's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::OpportunityCategory, nil].
-    def get_opportunity_category(id:)
+    def get_opportunity_category(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::OpportunityCategory.parse(request(:get, "OpportunityCategories/#{id}"))
     end
@@ -24,7 +24,7 @@ module Insightly2
     # @param [Hash] category The opportunity category to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::OpportunityCategory, nil].
-    def create_opportunity_category(category:)
+    def create_opportunity_category(category: nil)
       raise ArgumentError, "Category cannot be blank" if category.blank?
       Resources::OpportunityCategory.parse(request(:post, "OpportunityCategories", category))
     end
@@ -34,7 +34,7 @@ module Insightly2
     # @param [Hash] category The opportunity category to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::OpportunityCategory, nil].
-    def update_opportunity_category(category:)
+    def update_opportunity_category(category: nil)
       raise ArgumentError, "Category cannot be blank" if category.blank?
       Resources::OpportunityCategory.parse(request(:put, "OpportunityCategories", category))
     end
@@ -44,7 +44,7 @@ module Insightly2
     # @param [String, Fixnum] id A OpportunityCategory's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_opportunity_category(id:)
+    def delete_opportunity_category(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "OpportunityCategories/#{id}")
     end

--- a/lib/insightly2/dsl/organisations.rb
+++ b/lib/insightly2/dsl/organisations.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id An organisation's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Organisation, nil].
-    def get_organisation(id:)
+    def get_organisation(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Organisation.parse(request(:get, "Organisations/#{id}"))
     end
@@ -17,7 +17,7 @@ module Insightly2
     # @param [String, Fixnum] id An organisation's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_organisation_emails(id:)
+    def get_organisation_emails(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Email.parse(request(:get, "Organisations/#{id}/Emails"))
     end
@@ -27,7 +27,7 @@ module Insightly2
     # @param [String, Fixnum] id An organisation's ID
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def get_organisation_image(id:)
+    def get_organisation_image(id: nil)
       request(:get, "Organisations/#{id}/Image")
     end
 
@@ -36,7 +36,7 @@ module Insightly2
     # @param [String, Fixnum] id An organisation's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_organisation_notes(id:)
+    def get_organisation_notes(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Note.parse(request(:get, "Organisations/#{id}/Notes"))
     end
@@ -46,7 +46,7 @@ module Insightly2
     # @param [String, Fixnum] id An organisation's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_organisation_tasks(id:)
+    def get_organisation_tasks(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Task.parse(request(:get, "Organisations/#{id}/Tasks"))
     end
@@ -66,7 +66,7 @@ module Insightly2
     # @param [Hash] organisation The organisation to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Organisation].
-    def create_organisation(organisation:)
+    def create_organisation(organisation: nil)
       raise ArgumentError, "Organisation cannot be blank" if organisation.blank?
       Resources::Organisation.parse(request(:post, "Organisations", organisation))
     end
@@ -77,7 +77,7 @@ module Insightly2
     # @param [String] filename The name of the file.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def create_organisation_image(id:, filename:)
+    def create_organisation_image(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:post, "Organisations/#{id}/Image/#{filename}")
@@ -88,7 +88,7 @@ module Insightly2
     # @param [Hash] organisation The organisation to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Organisation, nil].
-    def update_organisation(organisation:)
+    def update_organisation(organisation: nil)
       raise ArgumentError, "Organisation cannot be blank" if organisation.blank?
       Resources::Organisation.parse(request(:put, "Organisations", organisation))
     end
@@ -99,7 +99,7 @@ module Insightly2
     # @param [String] filename name of the file.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def update_organisation_image(id:, filename:)
+    def update_organisation_image(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:put, "Organisations/#{id}/Image/#{filename}")
@@ -110,7 +110,7 @@ module Insightly2
     # @param [String, Fixnum] id An organisation's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_organisation(id:)
+    def delete_organisation(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Organisations/#{id}")
     end
@@ -120,7 +120,7 @@ module Insightly2
     # @param [String, Fixnum] id An organisation's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_organisation_image(id:)
+    def delete_organisation_image(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Organisations/#{id}/Image")
     end

--- a/lib/insightly2/dsl/pipeline_stages.rb
+++ b/lib/insightly2/dsl/pipeline_stages.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A pipeline stage's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::PipelineStage, nil].
-    def get_pipeline_stage(id:)
+    def get_pipeline_stage(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::PipelineStage.parse(request(:get, "PipelineStages/#{id}"))
     end

--- a/lib/insightly2/dsl/pipelines.rb
+++ b/lib/insightly2/dsl/pipelines.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A pipeline's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Pipeline, nil].
-    def get_pipeline(id:)
+    def get_pipeline(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Pipeline.parse(request(:get, "Pipelines/#{id}"))
     end

--- a/lib/insightly2/dsl/project_categories.rb
+++ b/lib/insightly2/dsl/project_categories.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A project category's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::ProjectCategory, nil].
-    def get_project_category(id:)
+    def get_project_category(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::ProjectCategory.parse(request(:get, "ProjectCategories/#{id}"))
     end
@@ -24,7 +24,7 @@ module Insightly2
     # @param [Hash] category: The project category to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::ProjectCategory, nil].
-    def create_project_category(category:)
+    def create_project_category(category: nil)
       raise ArgumentError, "Category cannot be blank" if category.blank?
       Resources::ProjectCategory.parse(request(:post, "ProjectCategories", category))
     end
@@ -34,7 +34,7 @@ module Insightly2
     # @param [Hash] category The project category to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::ProjectCategory, nil]
-    def update_project_category(category:)
+    def update_project_category(category: nil)
       raise ArgumentError, "Category cannot be blank" if category.blank?
       Resources::ProjectCategory.parse(request(:put, "ProjectCategories", category))
     end
@@ -44,7 +44,7 @@ module Insightly2
     # @param [String, Fixnum] id A project category's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_project_category(id:)
+    def delete_project_category(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "ProjectCategories/#{id}")
     end

--- a/lib/insightly2/dsl/projects.rb
+++ b/lib/insightly2/dsl/projects.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A project's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Project, nil].
-    def get_project(id:)
+    def get_project(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Project.parse(request(:get, "Projects/#{id}"))
     end
@@ -17,7 +17,7 @@ module Insightly2
     # @param [String, Fixnum] id A project's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_project_emails(id:)
+    def get_project_emails(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Email.parse(request(:get, "Projects/#{id}/Emails"))
     end
@@ -27,7 +27,7 @@ module Insightly2
     # @param [String, Fixnum] id A project's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def get_project_image(id:)
+    def get_project_image(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:get, "Projects/#{id}/Image")
     end
@@ -37,7 +37,7 @@ module Insightly2
     # @param [String, Fixnum] id A project's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_project_notes(id:)
+    def get_project_notes(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Note.parse(request(:get, "Projects/#{id}/Notes"))
     end
@@ -47,7 +47,7 @@ module Insightly2
     # @param [String, Fixnum] id A project's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_project_tasks(id:)
+    def get_project_tasks(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Task.parse(request(:get, "Projects/#{id}/Tasks"))
     end
@@ -67,7 +67,7 @@ module Insightly2
     # @param [Hash] project The project to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Project, nil].
-    def create_project(project:)
+    def create_project(project: nil)
       raise ArgumentError, "Project cannot be blank" if project.blank?
       Resources::Project.parse(request(:post, "Projects", project))
     end
@@ -78,7 +78,7 @@ module Insightly2
     # @param [String] filename A Project image file name.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def create_project_image(id:, filename:)
+    def create_project_image(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:post, "Projects/#{id}/Image/#{filename}")
@@ -89,7 +89,7 @@ module Insightly2
     # @param [Hash] project The project to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Project, nil].
-    def update_project(project:)
+    def update_project(project: nil)
       raise ArgumentError, "Project cannot be blank" if project.blank?
       Resources::Project.parse(request(:put, "Projects", project))
     end
@@ -100,7 +100,7 @@ module Insightly2
     # @param [String] filename A project image file name.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def update_project_image(id:, filename:)
+    def update_project_image(id: nil, filename: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Filename cannot be blank" if filename.blank?
       request(:put, "Projects/#{id}/Image/#{filename}")
@@ -111,7 +111,7 @@ module Insightly2
     # @param [String, Fixnum] id A project's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_project(id:)
+    def delete_project(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Projects/#{id}")
     end
@@ -121,7 +121,7 @@ module Insightly2
     # @param [String, Fixnum] id A project's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_project_image(id:)
+    def delete_project_image(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Projects/#{id}/Image")
     end

--- a/lib/insightly2/dsl/tags.rb
+++ b/lib/insightly2/dsl/tags.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A Tag's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Tag, nil].
-    def get_tag(id:)
+    def get_tag(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Tag.parse(request(:get, "Tags/#{id}"))
     end

--- a/lib/insightly2/dsl/task_categories.rb
+++ b/lib/insightly2/dsl/task_categories.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A task category's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::TaskCategory, nil].
-    def get_task_category(id:)
+    def get_task_category(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::TaskCategory.parse(request(:get, "TaskCategories/#{id}"))
     end
@@ -24,7 +24,7 @@ module Insightly2
     # @param [Hash] category The task category to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::TaskCategory, nil].
-    def create_task_category(category:)
+    def create_task_category(category: nil)
       raise ArgumentError, "Category cannot be blank" if category.blank?
       Resources::TaskCategory.parse(request(:post, "TaskCategories", category))
     end
@@ -34,7 +34,7 @@ module Insightly2
     # @param [Hash] category The task category to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::TaskCategory, nil].
-    def update_task_category(category:)
+    def update_task_category(category: nil)
       raise ArgumentError, "Category cannot be blank" if category.blank?
       Resources::TaskCategory.parse(request(:put, "TaskCategories", category))
     end
@@ -44,7 +44,7 @@ module Insightly2
     # @param [String, Fixnum] id A task category's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_task_category(id:)
+    def delete_task_category(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "TaskCategories/#{id}")
     end

--- a/lib/insightly2/dsl/tasks.rb
+++ b/lib/insightly2/dsl/tasks.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A Task's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Task, nil].
-    def get_task(id:)
+    def get_task(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Task.parse(request(:get, "Tasks/#{id}"))
     end
@@ -17,7 +17,7 @@ module Insightly2
     # @param [String, Fixnum] id A Task's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Array, nil].
-    def get_task_comments(id:)
+    def get_task_comments(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Comment.parse(request(:get, "Tasks/#{id}/Comments"))
     end
@@ -36,7 +36,7 @@ module Insightly2
     # @param [Hash] task The task to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Task, nil].
-    def create_task(task:)
+    def create_task(task: nil)
       raise ArgumentError, "Task cannot be blank" if task.blank?
       Resources::Task.parse(request(:post, "Tasks", task))
     end
@@ -47,7 +47,7 @@ module Insightly2
     # @param [Hash] comment The comment to create.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Comment, nil].
-    def create_task_comment(id:, comment:)
+    def create_task_comment(id: nil, comment: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       raise ArgumentError, "Comment cannot be blank" if comment.blank?
       Resources::Comment.parse(request(:post, "Tasks/#{id}/Comments", comment))
@@ -58,7 +58,7 @@ module Insightly2
     # @param [Hash] task The task to update.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Comment, nil].
-    def update_task(task:)
+    def update_task(task: nil)
       raise ArgumentError, "Task cannot be blank" if task.blank?
       Resources::Task.parse(request(:put, "Tasks", task))
     end
@@ -68,7 +68,7 @@ module Insightly2
     # @param [String, Fixnum] id A Task's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_task(id:)
+    def delete_task(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Tasks/#{id}")
     end

--- a/lib/insightly2/dsl/team_members.rb
+++ b/lib/insightly2/dsl/team_members.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A team member's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::TeamMember, nil].
-    def get_team_member(id:)
+    def get_team_member(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::TeamMember.parse(request(:get, "TeamMembers/#{id}"))
     end
@@ -16,7 +16,7 @@ module Insightly2
     # Get a list of team members.
     # @param [String, Fixnum] team_id: The ID of the team we're getting members for (optional).
     # @return [Array, nil]
-    def get_team_members(team_id:)
+    def get_team_members(team_id: nil)
       Resources::TeamMember.parse(request(:get, "TeamMembers/?teamid=#{team_id}"))
     end
 
@@ -25,7 +25,7 @@ module Insightly2
     # @param [Hash] team_member The team_member we're creating.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::TeamMember, nil].
-    def create_team_member(team_member:)
+    def create_team_member(team_member: nil)
       raise ArgumentError, "Team member cannot be blank" if team_member.blank?
       Resources::TeamMember.parse(request(:post, "TeamMembers", team_member))
     end
@@ -35,7 +35,7 @@ module Insightly2
     # @param [Hash] team_member The team_member we're updating.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::TeamMember, nil].
-    def update_team_member(team_member:)
+    def update_team_member(team_member: nil)
       raise ArgumentError, "Team member cannot be blank" if team_member.blank?
       Resources::TeamMember.parse(request(:put, "TeamMembers", team_member))
     end
@@ -45,7 +45,7 @@ module Insightly2
     # @param [String, Fixnum] id A team member's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_team_member(id:)
+    def delete_team_member(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "TeamMembers/#{id}")
     end

--- a/lib/insightly2/dsl/teams.rb
+++ b/lib/insightly2/dsl/teams.rb
@@ -8,7 +8,7 @@ module Insightly2
     # @param [String, Fixnum] id A team's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Team].
-    def get_team(id:)
+    def get_team(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::Team.parse(request(:get, "Teams/#{id}"))
     end
@@ -25,7 +25,7 @@ module Insightly2
     # @param [Hash] team The team we're creating.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Team, nil].
-    def create_team(team:)
+    def create_team(team: nil)
       raise ArgumentError, "Team cannot be blank" if team.blank?
       Resources::Team.parse(request(:post, "Teams", team))
     end
@@ -35,7 +35,7 @@ module Insightly2
     # @param [Hash] team The team we're updating.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::Team, nil].
-    def update_team(team:)
+    def update_team(team: nil)
       raise ArgumentError, "Team cannot be blank" if team.blank?
       Resources::Team.parse(request(:put, 'Teams', team))
     end
@@ -45,7 +45,7 @@ module Insightly2
     # @param [String, Fixnum] id A Team's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Faraday::Response].
-    def delete_team(id:)
+    def delete_team(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       request(:delete, "Teams/#{id}")
     end

--- a/lib/insightly2/dsl/users.rb
+++ b/lib/insightly2/dsl/users.rb
@@ -7,7 +7,7 @@ module Insightly2
     # @param [String, Fixnum] id A user's ID.
     # @raise [ArgumentError] If the method arguments are blank.
     # @return [Insightly2::Resources::User, nil].
-    def get_user(id:)
+    def get_user(id: nil)
       raise ArgumentError, "ID cannot be blank" if id.blank?
       Resources::User.parse(request(:get, "Users/#{id}"))
     end

--- a/lib/insightly2/errors/client_error.rb
+++ b/lib/insightly2/errors/client_error.rb
@@ -2,7 +2,7 @@ module Insightly2
   module Errors
     class ClientError < StandardError
       attr_reader :response
-      def initialize(response:)
+      def initialize(response: nil)
         @response = response
       end
     end

--- a/lib/insightly2/utils/url_helper.rb
+++ b/lib/insightly2/utils/url_helper.rb
@@ -5,7 +5,7 @@ module Insightly2
       # @param [UrlHelper] path The name of the resource path as per the URL e.g. contacts.
       # @param [Hash] params A hash of params we're turning into a querystring.
       # @return [UrlHelper] The URL of the resource with required params.
-      def self.build_url(path:, params:)
+      def self.build_url(path: nil, params: nil)
         params.delete_if {|k,v| v.blank?}
         params = params.to_query
         query = path


### PR DESCRIPTION
This gem previously did not work with Ruby 2.0 due to the omission of default values for keyword arguments, which is valid in Ruby 2.1. Adding these values allows the gem to be used with Ruby 2.0.