### PR TITLE
Will create a new client if it detects a changed api_key.

### DIFF
--- a/lib/insightly2.rb
+++ b/lib/insightly2.rb
@@ -17,6 +17,10 @@ module Insightly2
 
   # @return [Insightly2::Client]
   def client
-    @client ||= Client.new(Insightly2.api_key)
+    if @client && @client.api_key != self.api_key
+      @client = Client.new(Insightly2.api_key) #force new client in case api_key has changed
+    else
+      @client ||= Client.new(Insightly2.api_key)
+    end
   end
 end

--- a/lib/insightly2/client.rb
+++ b/lib/insightly2/client.rb
@@ -16,6 +16,8 @@ module Insightly2
     HEADERS = {'Accept' => 'application/json', 'Content-Type' => 'application/json'}
     LOGGER = Logger.new(STDOUT)
 
+    attr_reader :api_key
+
     # @param [String] api_key
     def initialize(api_key = Insightly2.api_key)
       @api_key = api_key


### PR DESCRIPTION
Currently when you create 

```
Insightly2.api_key = 'cdeda94f-af17-4b8b-9932-xxxxxxxxxxxx'
contacts = Insightly2.client.get_contacts
```

and some time later you do:

```
Insightly2.api_key = 'cdeda94f-af17-4b8b-9932-yyyyyyyyyyyy'
contacts = Insightly2.client.get_contacts
```

it will still use the previous key (...xxxxx) since @client already exists and there is no detection of a changed api_key.

This PR fixes that and will create a new client if it detects a different api_key
