### PR TITLE
Added query_params to get_contacts, get_projects, for filtering

### DIFF
--- a/lib/insightly2/dsl/contacts.rb
+++ b/lib/insightly2/dsl/contacts.rb
@@ -58,8 +58,8 @@ module Insightly2
     # @param [String] email The email address of the contact to return (optional).
     # @param [String] tag The tag that has been applied to contacts (optional).
     # @return [Array, nil].
-    def get_contacts(ids: [], email: '', tag: '')
-      url = Utils::UrlHelper.build_url(path: "Contacts", params: {ids: ids.join(','), email: email, tag: tag})
+    def get_contacts(ids: [], email: '', tag: '', query_params: {})
+      url = Utils::UrlHelper.build_url(path: "Contacts", params: {ids: ids.join(','), email: email, tag: tag}.merge(query_params))
       Resources::Contact.parse(request(:get, url))
     end
 

--- a/lib/insightly2/dsl/emails.rb
+++ b/lib/insightly2/dsl/emails.rb
@@ -27,8 +27,8 @@ module Insightly2
     # @param [Array] ids The list of email IDs (optional).
     # @param [String] tag Emails tagged with this tag (optional).
     # @return [Array, nil].
-    def get_emails(ids: [], tag: '')
-      url = Utils::UrlHelper.build_url(path: "Emails", params: {ids: ids.join(','), tag: tag})
+    def get_emails(ids: [], tag: '', query_params: {})
+      url = Utils::UrlHelper.build_url(path: "Emails", params: {ids: ids.join(','), tag: tag}.merge(query_params))
       Resources::Email.parse(request(:get, url))
     end
 

--- a/lib/insightly2/dsl/notes.rb
+++ b/lib/insightly2/dsl/notes.rb
@@ -25,8 +25,9 @@ module Insightly2
     # GET /v2.1/Notes
     # Get a list of notes.
     # @return [Insightly2::Resources::Note, nil].
-    def get_notes
-      Resources::Note.parse(request(:get, "Notes"))
+    def get_notes(query_params: {})
+      url = Utils::UrlHelper.build_url(path: "Notes", params: query_params)
+      Resources::Note.parse(request(:get, url))
     end
 
     # POST /v2.1/Notes

--- a/lib/insightly2/dsl/opportunities.rb
+++ b/lib/insightly2/dsl/opportunities.rb
@@ -65,8 +65,8 @@ module Insightly2
     # @param [Array] ids IDs of opportunities (optional).
     # @param [String] tag The tag that has been applied to an opportunity (optional).
     # @return [Array, nil].
-    def get_opportunities(ids: [], tag: '')
-      url = Utils::UrlHelper.build_url(path: "Opportunities", params: {ids: ids.join(','), tag: tag})
+    def get_opportunities(ids: [], tag: '', query_params: {})
+      url = Utils::UrlHelper.build_url(path: "Opportunities", params: {ids: ids.join(','), tag: tag}.merge(query_params))
       Resources::Opportunity.parse(request(:get, url))
     end
 

--- a/lib/insightly2/dsl/organisations.rb
+++ b/lib/insightly2/dsl/organisations.rb
@@ -56,8 +56,8 @@ module Insightly2
     # @param [String] domain The email domain (optional).
     # @param [String] tag The tag an organisation has been tagged with (optional).
     # @return [Array, nil].
-    def get_organisations(ids: [], domain: '', tag: '')
-      url = Utils::UrlHelper.build_url(path: "Organisations", params: {ids: ids.join(','), domain: domain, tag: tag})
+    def get_organisations(ids: [], domain: '', tag: '', query_params: {})
+      url = Utils::UrlHelper.build_url(path: "Organisations", params: {ids: ids.join(','), domain: domain, tag: tag}.merge(query_params))
       Resources::Organisation.parse(request(:get, url))
     end
 

--- a/lib/insightly2/dsl/projects.rb
+++ b/lib/insightly2/dsl/projects.rb
@@ -57,8 +57,8 @@ module Insightly2
     # @param [Array] ids The IDs of the projects to retrieve (optional).
     # @param [String] tag The tag that is applied to the projects (optional).
     # @return [Array, nil].
-    def get_projects(ids: [], tag: '')
-      url = Utils::UrlHelper.build_url(path: "Projects", params: {ids: ids.join(','), tag: tag})
+    def get_projects(ids: [], tag: '', query_params: {})
+      url = Utils::UrlHelper.build_url(path: "Projects", params: {ids: ids.join(','), tag: tag}.merge(query_params))
       Resources::Project.parse(request(:get, url))
     end
 

--- a/lib/insightly2/dsl/tasks.rb
+++ b/lib/insightly2/dsl/tasks.rb
@@ -26,8 +26,8 @@ module Insightly2
     # Get a list of tasks.
     # @param [ids:] Array of task ids (optional).
     # @return [Insightly2::Resources::Task, nil].
-    def get_tasks(ids: [])
-      url = Utils::UrlHelper.build_url(path: "Tasks", params: {ids: ids.join(',')})
+    def get_tasks(ids: [], query_params: {})
+      url = Utils::UrlHelper.build_url(path: "Tasks", params: {ids: ids.join(',')}.merge(query_params))
       Resources::Task.parse(request(:get, url))
     end
 


### PR DESCRIPTION
This commit enables OData filtering which wasn't possible before.

See here: https://api.insight.ly/v2.1/Help/TechnicalDetails for details.

I have enabled this for:

get_contacts
get_organisations
get_opportunities
get_projects
get_tasks
get_emails
get_notes

This is backwards compatible.

You can use it like this:

```ruby
last_sync_time = (user.insightly['insightly_last_sync'].to_time).utc.strftime('%FT%T')
client.get_contacts(query_params: { '$filter' => "DATE_UPDATED_UTC gt DateTime'#{last_sync_time}'" })
```

You can also use query_params to only return parent objects like this:

```ruby
client.get_contacts(query_params: { 'Brief' => :True })
```

Or you can of course combine both:
```ruby
client.get_contacts(query_params: { 'Brief' => :True, '$filter' => "DATE_UPDATED_UTC gt DateTime'#{last_sync_time}'" })
```